### PR TITLE
Better user experience for stack timeouts

### DIFF
--- a/application/commands/common.go
+++ b/application/commands/common.go
@@ -54,10 +54,11 @@ func (c *AWSConfig) buildClient() (*awsclient.Client, error) {
 	}
 
 	config := awsclient.Config{
-		Region:            load(c.Region),
-		AccessKey:         load(c.AccessKey),
-		SecretKey:         load(c.SecretKey),
-		EndpointOverrides: endpointOverrides,
+		Region:                    load(c.Region),
+		AccessKey:                 load(c.AccessKey),
+		SecretKey:                 load(c.SecretKey),
+		EndpointOverrides:         endpointOverrides,
+		CloudFormationWaitTimeout: c.StackWaitTimeout,
 	}
 
 	if missing {

--- a/application/commands/inputs.go
+++ b/application/commands/inputs.go
@@ -1,5 +1,7 @@
 package commands
 
+import "time"
+
 type CLIOptions struct {
 	Name      string    `short:"n" long:"name"  description:"Name of environment to manipulate"`
 	AWSConfig AWSConfig `group:"aws"`
@@ -26,10 +28,12 @@ type Show struct {
 }
 
 type AWSConfig struct {
-	Region            string `long:"aws-region" env:"AWS_DEFAULT_REGION" description:"defaults to"`
-	AccessKey         string `long:"aws-access-key" env:"AWS_ACCESS_KEY_ID" description:"defaults to"`
-	SecretKey         string `long:"aws-secret-key" env:"AWS_SECRET_ACCESS_KEY" description:"defaults to"`
-	EndpointOverrides string `long:"endpoint-overrides" env:"TUBES_AWS_ENDPOINTS" description:"JSON hash of AWS endpoint URLs.  Override for testing."`
+	Region    string `long:"aws-region" env:"AWS_DEFAULT_REGION" description:"defaults to"`
+	AccessKey string `long:"aws-access-key" env:"AWS_ACCESS_KEY_ID" description:"defaults to"`
+	SecretKey string `long:"aws-secret-key" env:"AWS_SECRET_ACCESS_KEY" description:"defaults to"`
+
+	EndpointOverrides string        `long:"endpoint-overrides" env:"TUBES_AWS_ENDPOINTS" description:"JSON hash of AWS endpoint URLs.  Override for testing."`
+	StackWaitTimeout  time.Duration `long:"stack-wait-timeout" default:"7m" description:"maximum time to wait for CloudFormation stack changes"`
 }
 
 func New() *CLIOptions {

--- a/application/up.go
+++ b/application/up.go
@@ -51,7 +51,7 @@ func (a *Application) Boot(stackName string) error {
 		"KeyName":        stackName,
 	}
 	templateJSON := awsclient.BaseStackTemplate.String()
-	a.Logger.Println("Upserting stack...")
+	a.Logger.Println("Upserting stack.  Check CloudFormation console for details.")
 	err = a.AWSClient.UpsertStack(stackName, templateJSON, parameters)
 	if err != nil {
 		return err

--- a/application/up_test.go
+++ b/application/up_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Up", func() {
 		Expect(logBuffer).To(gbytes.Say("Creating keypair"))
 		Expect(logBuffer).To(gbytes.Say("Looking for latest AWS NAT box AMI..."))
 		Expect(logBuffer).To(gbytes.Say("Latest NAT box AMI is \"some-nat-box-ami-id\""))
-		Expect(logBuffer).To(gbytes.Say("Upserting stack..."))
+		Expect(logBuffer).To(gbytes.Say("Upserting stack.  Check CloudFormation console for details."))
 		Expect(logBuffer).To(gbytes.Say("Stack update complete"))
 		Expect(logBuffer).To(gbytes.Say("Generating BOSH init manifest"))
 		Expect(logBuffer).To(gbytes.Say("Downloading the concourse manifest from " + app.ConcourseTemplateURL))
@@ -191,7 +191,7 @@ var _ = Describe("Up", func() {
 			configStore.Errors["ssh-key"] = errors.New("some error")
 
 			Expect(app.Boot(stackName)).To(MatchError("some error"))
-			Expect(logBuffer.Contents()).NotTo(ContainSubstring("Upserting stack..."))
+			Expect(logBuffer.Contents()).NotTo(ContainSubstring("Upserting stack"))
 			Expect(logBuffer.Contents()).NotTo(ContainSubstring("Finished"))
 		})
 	})

--- a/lib/awsclient/client.go
+++ b/lib/awsclient/client.go
@@ -76,8 +76,9 @@ func New(config Config) (*Client, error) {
 	session := session.New(sdkConfig)
 
 	if config.CloudFormationWaitTimeout == 0 {
-		config.CloudFormationWaitTimeout = 5 * time.Minute
+		return nil, fmt.Errorf("AWS config CloudFormationWaitTimeout must be a positive timeout")
 	}
+
 	ec2EndpointConfig, err := config.getEndpoint("ec2")
 	if err != nil {
 		return nil, err

--- a/lib/awsclient/stack_wait.go
+++ b/lib/awsclient/stack_wait.go
@@ -40,7 +40,7 @@ func (c *Client) WaitForStack(stackName string, pundit CloudFormationStatusPundi
 		}
 
 		if elapsed >= c.CloudFormationWaitTimeout {
-			return fmt.Errorf("timed out waiting for stack change to complete (max %s, %s)", elapsed, status)
+			return fmt.Errorf("timed out waiting for stack change to complete (max %s, %s).  Check CloudFormation for details.", elapsed, status)
 		}
 		c.Clock.Sleep(sleepDuration)
 		elapsed += sleepDuration

--- a/lib/awsclient/stack_wait_test.go
+++ b/lib/awsclient/stack_wait_test.go
@@ -142,7 +142,7 @@ var _ = Describe("waiting for the stack changes to complete", func() {
 			}
 
 			Expect(client.WaitForStack(stackName, pundit)).To(MatchError(
-				"timed out waiting for stack change to complete (max 1m5s, some status 13)"))
+				"timed out waiting for stack change to complete (max 1m5s, some status 13).  Check CloudFormation for details."))
 		})
 	})
 


### PR DESCRIPTION
- Wait timeout is now 7 minutes instead of 5
- Wait timeout is configurable via `--stack-wait-timeout` CLI flag
- CLI output messages include hint to look at CloudFormation console

Fixes #3 
